### PR TITLE
Duplicate config for Postgres driver and hiding google docs comments if not relavent

### DIFF
--- a/generators/app/templates/6.2/docker-compose.yml
+++ b/generators/app/templates/6.2/docker-compose.yml
@@ -15,7 +15,6 @@ services:
             - mariadb <% } %>
         environment:
             JAVA_OPTS : '
-                -Ddb.driver=org.postgresql.Driver
                 -Ddb.username=alfresco
                 -Ddb.password=alfresco<% if (db == "postgres") { %>
                 -Ddb.driver=org.postgresql.Driver

--- a/generators/app/templates/7.0/docker-compose.yml
+++ b/generators/app/templates/7.0/docker-compose.yml
@@ -24,7 +24,6 @@ services:
                 -Dmetadata-keystore.metadata.algorithm=DESede
                 "
             JAVA_OPTS : '
-                -Ddb.driver=org.postgresql.Driver
                 -Ddb.username=alfresco
                 -Ddb.password=alfresco<% if (db == "postgres") { %>
                 -Ddb.driver=org.postgresql.Driver

--- a/generators/app/templates/7.1/docker-compose.yml
+++ b/generators/app/templates/7.1/docker-compose.yml
@@ -24,7 +24,6 @@ services:
                 -Dmetadata-keystore.metadata.algorithm=DESede
                 "
             JAVA_OPTS : '
-                -Ddb.driver=org.postgresql.Driver
                 -Ddb.username=alfresco
                 -Ddb.password=alfresco<% if (db == "postgres") { %>
                 -Ddb.driver=org.postgresql.Driver

--- a/generators/app/templates/images/share/Dockerfile
+++ b/generators/app/templates/images/share/Dockerfile
@@ -13,8 +13,8 @@ RUN sed -i '/Connector port="8080"/a scheme="https" secure="true"' /usr/local/to
     sed -i "/Connector port=\"8080\"/a proxyName=\"${SERVER_NAME}\" proxyPort=\"<%=port%>\"" /usr/local/tomcat/conf/server.xml
 <% } %>
 
-# Uninstall manually Share GoogleDocs module
 <%if (googledocs == 'false' && acsVersion < '7') { %>
+# Uninstall manually Share GoogleDocs module
 RUN rm $TOMCAT_DIR/webapps/share/WEB-INF/lib/alfresco-googledocs-share-community-*.jar && \
     rm $TOMCAT_DIR/webapps/share/WEB-INF/classes/alfresco/web-extension/custom-slingshot-googledocs-context.xml && \
     rm $TOMCAT_DIR/webapps/share/WEB-INF/classes/alfresco/messages/googledocs_* && \


### PR DESCRIPTION
Does not affect the running the application but I found the google docs comment confusing when I was going through the dockerfile for share as I had opted to leave google docs on