### PR TITLE
Fix for the issue #123

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -203,9 +203,6 @@ module.exports = class extends Generator {
       },
       {
         // Provide volumes permission script for Linux OS
-        when: function () {
-          return !process.platform == 'win32' && !process.platform == 'darwin';
-        },
         type: 'confirm',
         name: 'volumesscript',
         message: 'Do you want to get the script to create host volumes?',


### PR DESCRIPTION
This was fixed by simply removing the when clause, and letting the user answer if the script should be created or not, in the same way it already does for the start script creation.