### PR TITLE
Update Yoeman requirements to support Node.js version 14 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This program has following dependencies:
 * Node.js
 * Yeoman
 
-Yoeman requires the Node to have a version higher than v14
+Yeoman requires the Node to have a version higher than v14
 
 You can download and install `Node.js` from official web page:
 


### PR DESCRIPTION
This pull request aims to update the Yoeman requirement to support Node.js version 14 or higher. 

After some errors received when upgrading to the latest version of the alfresco docker installer. I realized that the error came from the version I was using of node: 12.22.9
 After upgrading to a newer version, I noticed that the error was gone.

Main changes made to this pull request:
- Updated the readme to specify the minimum version as 14.
- After testing on real projects, verified the requirement of Node with version higher than 14.

In addition, I ran a series of tests to ensure that the project continues to work correctly with the new version of Node. All tests passed successfully.

I appreciate the review of this pull request and am open to any suggestions or additional modifications.

Thanks!