### PR TITLE
Add ActiveMQ to OCR and Transform

### DIFF
--- a/generators/app/templates/6.2/docker-compose.yml
+++ b/generators/app/templates/6.2/docker-compose.yml
@@ -101,6 +101,7 @@ services:
         image: alfresco/alfresco-pdf-renderer:${TRANSFORM_ENGINE_TAG}
         mem_limit: 512m
         environment:
+            ACTIVEMQ_URL: "nio://activemq:61616"
             JAVA_OPTS: " -Xms256m -Xmx512m"
         ports:
             - 8090:8090
@@ -109,6 +110,7 @@ services:
         image: alfresco/alfresco-imagemagick:${TRANSFORM_ENGINE_TAG}
         mem_limit: 512m
         environment:
+            ACTIVEMQ_URL: "nio://activemq:61616"
             JAVA_OPTS: " -Xms256m -Xmx512m"
         ports:
             - 8091:8090
@@ -117,6 +119,7 @@ services:
         image: alfresco/alfresco-libreoffice:${TRANSFORM_ENGINE_TAG}
         mem_limit: 512m
         environment:
+            ACTIVEMQ_URL: "nio://activemq:61616"
             JAVA_OPTS: " -Xms512m -Xmx1024m"
         ports:
             - 8092:8090
@@ -125,6 +128,7 @@ services:
         image: alfresco/alfresco-tika:${TRANSFORM_ENGINE_TAG}
         mem_limit: 512m
         environment:
+            ACTIVEMQ_URL: "nio://activemq:61616"
             JAVA_OPTS: " -Xms512m -Xmx1024m"
         ports:
             - 8093:8090
@@ -133,6 +137,7 @@ services:
         image: alfresco/alfresco-transform-misc:${TRANSFORM_ENGINE_TAG}
         mem_limit: 512m
         environment:
+            ACTIVEMQ_URL: "nio://activemq:61616"
             JAVA_OPTS: " -Xms256m -Xmx512m"
         ports:
             - 8094:8090

--- a/generators/app/templates/7.0/docker-compose.yml
+++ b/generators/app/templates/7.0/docker-compose.yml
@@ -101,6 +101,7 @@ services:
         image: alfresco/alfresco-transform-core-aio:${TRANSFORM_ENGINE_TAG}
         mem_limit: 2048m
         environment:
+            ACTIVEMQ_URL: "nio://activemq:61616"
             JAVA_OPTS: "
                 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80
                 -Dserver.tomcat.threads.max=12
@@ -292,6 +293,7 @@ services:
         image: angelborroy/alfresco-tengine-ocr:1.0.0
         mem_limit: 1536m
         environment:
+          ACTIVEMQ_URL: "nio://activemq:61616"
           JAVA_OPTS: "
               -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80
               -Dserver.tomcat.threads.max=4

--- a/generators/app/templates/7.1/docker-compose.yml
+++ b/generators/app/templates/7.1/docker-compose.yml
@@ -122,6 +122,7 @@ services:
         image: alfresco/alfresco-transform-core-aio:${TRANSFORM_ENGINE_TAG}
         mem_limit: 2048m
         environment:
+            ACTIVEMQ_URL: "nio://activemq:61616"
             JAVA_OPTS: "
                 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80
                 -Dserver.tomcat.threads.max=12
@@ -343,6 +344,7 @@ services:
         image: angelborroy/alfresco-tengine-ocr:1.0.0
         mem_limit: 1536m
         environment:
+          ACTIVEMQ_URL: "nio://activemq:61616"
           JAVA_OPTS: "
               -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80
               -Dserver.tomcat.threads.max=4

--- a/generators/app/templates/7.2/docker-compose.yml
+++ b/generators/app/templates/7.2/docker-compose.yml
@@ -122,6 +122,7 @@ services:
         image: alfresco/alfresco-transform-core-aio:${TRANSFORM_ENGINE_TAG}
         mem_limit: 2048m
         environment:
+            ACTIVEMQ_URL: "nio://activemq:61616"
             JAVA_OPTS: "
               -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80
               -Dserver.tomcat.threads.max=12
@@ -344,6 +345,7 @@ services:
         image: angelborroy/alfresco-tengine-ocr:1.0.0
         mem_limit: 1536m
         environment:
+          ACTIVEMQ_URL: "nio://activemq:61616"
           JAVA_OPTS: "
               -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80
               -Dserver.tomcat.threads.max=4

--- a/generators/app/templates/7.3/docker-compose.yml
+++ b/generators/app/templates/7.3/docker-compose.yml
@@ -124,6 +124,7 @@ services:
         image: <%=repository%>/alfresco-transform-core-aio:${TRANSFORM_ENGINE_TAG}
         mem_limit: 2048m
         environment:
+            <% if (activemq == 'true') { %>ACTIVEMQ_URL: "nio://activemq:61616"<%} %>
             JAVA_OPTS: "
               -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80
               -Dserver.tomcat.threads.max=12
@@ -349,6 +350,7 @@ services:
         image: angelborroy/alfresco-tengine-ocr:1.0.0
         mem_limit: 1536m
         environment:
+          <% if (activemq == 'true') { %>ACTIVEMQ_URL: "nio://activemq:61616"<%} %>
           JAVA_OPTS: "
               -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80
               -Dserver.tomcat.threads.max=4


### PR DESCRIPTION
After some search and testing, I believe that adding by default the ActiveMQ to the containers would be a good ideia, specially because the Queue, if the server goes down, when the server goes up again the OCR and Transform can start where they stopped.