### PR TITLE
Add --searchType=jeci: vanilla Solr 9 / Java 17 search for ACS 26.1 (v1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,23 @@ By default, many organizations are storing documents in different languages or t
 By default, Alfresco is indexing the content of a document (in addition to the metadata). Disable this option if you don't require searching by the content of the documents.
 
 ```
+? Which search engine would you like to use?
+  Alfresco Search Services (stock, Solr 6)
+  Jeci community fork (vanilla Solr 9 / Java 17, standalone trackers)
+```
+
+This question is **only available for ACS 26.1**. By default the stock **Alfresco Search Services** image (Apache Solr 6) is used.
+
+The **Jeci community fork** ([jecicorp/AlfrescoSearchServices](https://github.com/jecicorp/AlfrescoSearchServices)) runs search on **vanilla Apache Solr 9 / Java 17** and splits the search tier into **two services**: `solr6` (query serving + index storage) and `trackers` (the indexing trackers, externalized into a standalone Spring Boot service). The trackers can be re-tuned live through `ALFRESCO_TRACKER_*` environment variables without rebuilding any image.
+
+Notes when selecting the Jeci fork:
+
+* It is a **beta**, community-maintained fork — not affiliated with Hyland and not recommended for production yet.
+* Communication with the Repository is forced to **shared secret** (the `Alfresco-SOLR communication` question below is skipped); the fork does not yet support mTLS on the trackers → Solr leg.
+* The images are **not published to a public registry** yet, so build them locally and point `SEARCH_JECI_IMAGE` / `TRACKERS_JECI_IMAGE` in `.env` at your local tags (defaults: `alfresco/alfresco-search-services:local` and `alfresco/alfresco-indexing-trackers:local`).
+* A full re-index is required (Lucene 9 cannot read a Solr 6 index); start with empty cores and let the trackers rebuild from the Repository.
+
+```
 ? Would you like to use HTTP or Shared Secret for Alfresco-SOLR communication?
   http  << Not available when using ACS 7.2+
   https
@@ -396,6 +413,7 @@ $ yo alfresco-docker-installer --acsVersion=6.1
 * `--mariadb`: true or false
 * `--crossLocale`: true or false
 * `--enableContentIndexing`: true or false
+* `--searchType`: alfresco or jeci (only for ACS 26.1, defaults to alfresco; `jeci` forces `--solrHttpMode=secret`)
 * `--solrHttpMode`: http, https or secret
 * `--activemq`: true or false (ACS 7.3+)
 * `--smtp`: true or false
@@ -414,6 +432,29 @@ yo alfresco-docker-installer \
   --https=true \
   --serverName=alfresco.example.com \
   --port=443
+```
+
+**Example with the Jeci Solr 9 community fork (ACS 26.1 only):**
+
+```bash
+yo alfresco-docker-installer \
+  --acsVersion=26.1 \
+  --searchType=jeci \
+  --ram=16 \
+  --serverName=localhost \
+  --port=80
+```
+
+Before `docker compose up`, build the fork's images locally (they are not published to a public registry yet) and, if you tagged them differently, set `SEARCH_JECI_IMAGE` / `TRACKERS_JECI_IMAGE` in the generated `.env`:
+
+```bash
+git clone https://github.com/jecicorp/AlfrescoSearchServices.git
+cd AlfrescoSearchServices
+mise run install && mise run trackers:build
+docker build -t alfresco/alfresco-search-services:local search-services/packaging/target/docker-resources/
+docker build -t alfresco/alfresco-indexing-trackers:local \
+  -f search-services/packaging/src/docker/Dockerfile.trackers \
+  search-services/alfresco-indexing-trackers/target/
 ```
 
 **Note on boolean flags**: Yeoman treats boolean flags as true when present. To set a flag to true, include it (e.g., `--https`). To set it to false, omit the flag entirely. Do NOT use `--flag=false` syntax as it will be interpreted as true.
@@ -504,7 +545,9 @@ Runtime bind-mount folders under `data/` and `logs/` are typically created after
 │   ├── slapd               > [LDAP] OpenLDAP storage
 │   │   ├── config
 │   │   └── database
-│   └── solr-data           > Internal storage for Search Services
+│   ├── solr-data           > Internal storage for Search Services
+│   ├── solr-solrhome        > [searchType=jeci] Solr 9 cores/config (solrhome)
+│   └── trackers-data        > [searchType=jeci] Standalone trackers model store
 
 ├── docker-compose.yml      > Main Docker Compose template
 ├── create_volumes.sh       > [Optional] Helper script to prepare Linux/macOS bind mounts
@@ -524,7 +567,7 @@ Runtime bind-mount folders under `data/` and `logs/` are typically created after
 │   ├── Dockerfile          > Docker image for ocrmypdf
 │   └── assets              > OCR service configuration assets
 
-├── search                  > Search Services image build context
+├── search                  > Search Services image build context (omitted when searchType=jeci, which uses prebuilt images)
 │   └── Dockerfile          > Docker image for Search Services
 
 ├── share                   > Share image build context

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -33,6 +33,7 @@ export default class AppGenerator extends Generator {
     this.option('mariadb', { type: Boolean, description: 'Use MariaDB instead of PostgreSQL' });
     this.option('crossLocale', { type: Boolean, description: 'Support multiple languages' });
     this.option('enableContentIndexing', { type: Boolean, description: 'Enable content indexing in documents' });
+    this.option('searchType', { type: String, description: 'Search engine: alfresco (stock Search Services) or jeci (Solr 9 / Java 17 community fork with standalone trackers) (ACS 26.1 only)' });
     this.option('solrHttpMode', { type: String, description: 'Alfresco-SOLR communication: http, https, or secret' });
     this.option('activemq', { type: Boolean, description: 'Enable Events service (ActiveMQ)' });
     this.option('activeMqCredentials', { type: Boolean, description: 'Use credentials for ActiveMQ' });
@@ -115,7 +116,7 @@ export default class AppGenerator extends Generator {
 
     const prompts = [
       {
-        type: 'list',
+        type: 'select',
         name: 'acsVersion',
         message: 'Which ACS version do you want to use?',
         choices: [ '6.1', '6.2', '7.0', '7.1', '7.2', '7.3', '7.4', '23.1', '23.2', '23.3', '23.4', '25.1', '25.2', '25.3', '26.1' ],
@@ -148,7 +149,7 @@ export default class AppGenerator extends Generator {
           var version = response.acsVersion || self.options.acsVersion;
           return version === '26.1';
         },
-        type: 'list',
+        type: 'select',
         name: 'proxyType',
         message: 'Which proxy would you like to use?',
         choices: ['nginx', 'traefik'],
@@ -248,9 +249,24 @@ export default class AppGenerator extends Generator {
       {
         when: function (response) {
           var version = response.acsVersion || self.options.acsVersion;
-          return version === '7.1';
+          return version === '26.1';
         },
-        type: 'list',
+        type: 'select',
+        name: 'searchType',
+        message: 'Which search engine would you like to use?',
+        choices: [
+          { name: 'Alfresco Search Services (stock, Solr 6)', value: 'alfresco' },
+          { name: 'Jeci community fork (vanilla Solr 9 / Java 17, standalone trackers)', value: 'jeci' }
+        ],
+        default: 'alfresco'
+      },
+      {
+        when: function (response) {
+          var version = response.acsVersion || self.options.acsVersion;
+          var search = response.searchType !== undefined ? response.searchType : self.options.searchType;
+          return version === '7.1' && search !== 'jeci';
+        },
+        type: 'select',
         name: 'solrHttpMode',
         message: 'Would you like to use HTTP, HTTPs or Shared Secret for Alfresco-SOLR communication?',
         choices: [ 'http', 'https', 'secret' ],
@@ -259,9 +275,12 @@ export default class AppGenerator extends Generator {
       {
         when: function (response) {
           var version = response.acsVersion || self.options.acsVersion;
-          return compare(version, '7.2', '>=');
+          var search = response.searchType !== undefined ? response.searchType : self.options.searchType;
+          // The Jeci fork only supports shared-secret end to end (its trackers->Solr
+          // leg has no mTLS), so solrHttpMode is forced to 'secret' for it.
+          return compare(version, '7.2', '>=') && search !== 'jeci';
         },
-        type: 'list',
+        type: 'select',
         name: 'solrHttpMode',
         message: 'Would you like to use Shared Secret or HTTPs for Alfresco-SOLR communication?',
         choices: [ 'secret', 'https' ],
@@ -430,6 +449,7 @@ export default class AppGenerator extends Generator {
           windows: (this.props.windows ? 'true' : 'false'),
           googledocs: (this.props.addons.includes('google-docs') ? 'true' : 'false'),
           serverName: this.props.serverName,
+          searchType: this.props.searchType,
           solrHttpMode: this.props.solrHttpMode,
           secureComms: (this.props.solrHttpMode === 'http' ? 'none' : this.props.solrHttpMode),
           // Generate random password for Repo-SOLR secret communication method
@@ -471,14 +491,24 @@ export default class AppGenerator extends Generator {
           serverName: this.props.serverName
         }
       );
-      // Copy Docker Image for Search applying configuration
-      this.fs.copyTpl(
-        this.templatePath('images/search'),
-        this.destinationPath('search'),
-        {
-          repository: (this.props.arch ? 'angelborroy' : 'alfresco')
-        }
-      );
+      // Copy Docker Image for Search applying configuration.
+      // The Jeci fork ships a multi-stage Dockerfile that compiles the fork from
+      // source (so no local JDK/Maven or manual clone is needed); the stock build
+      // uses the prebuilt Search Services image as a base.
+      if (this.props.searchType === 'jeci') {
+        this.fs.copy(
+          this.templatePath('images/search-jeci'),
+          this.destinationPath('search')
+        );
+      } else {
+        this.fs.copyTpl(
+          this.templatePath('images/search'),
+          this.destinationPath('search'),
+          {
+            repository: (this.props.arch ? 'angelborroy' : 'alfresco')
+          }
+        );
+      }
       // Copy Proxy Configuration (nginx.conf for nginx, nginx.htpasswd for both nginx and Traefik)
       this.fs.copyTpl(
         this.templatePath('images/config/nginx'),
@@ -636,6 +666,23 @@ export default class AppGenerator extends Generator {
    * Show warnings and informational messages
    */
   showWarnings() {
+    if (this.props.searchType === 'jeci') {
+      this.log('\n   ---------------------------------------------------------------\n' +
+        '   NOTE: You selected the Jeci community fork of Alfresco Search \n' +
+        '   Services (vanilla Apache Solr 9 / Java 17). This is a BETA, \n' +
+        '   community-maintained fork, not affiliated with Hyland and not \n' +
+        '   for production use yet. \n\n' +
+        '   The search tier now runs as TWO services: "solr6" (query + index \n' +
+        '   storage) and "trackers" (the standalone indexing trackers). \n' +
+        '   Communication with the Repository uses shared secret. \n\n' +
+        '   The ./search Dockerfile compiles the fork FROM SOURCE (Java 17) on \n' +
+        '   first build, so no local JDK/Maven is needed. The initial \n' +
+        '   "docker compose up --build" downloads + compiles and may take a \n' +
+        '   while; later builds are cached. Pick a branch/tag/commit with \n' +
+        '   JECI_REPO / JECI_REF in .env. \n' +
+        '   https://github.com/jecicorp/AlfrescoSearchServices \n' +
+        '   ---------------------------------------------------------------\n');
+    }
     if (this.props.addons.includes('share-site-creators')) {
       this.log('\n   ---------------------------------------------------\n' +
         '   WARNING: You selected the addon share-site-creators. \n' +
@@ -745,6 +792,17 @@ function usesActiveMqCredentials(props) {
 }
 
 function applyDerivedDefaults(props) {
+  // Search engine: only ACS 26.1 can select the Jeci fork; everything else uses stock.
+  if (props.searchType !== 'jeci' || props.acsVersion !== '26.1') {
+    props.searchType = 'alfresco';
+  }
+
+  // The Jeci fork (Solr 9 / standalone trackers) only supports shared-secret
+  // communication end to end, so force it regardless of any solrHttpMode input.
+  if (props.searchType === 'jeci') {
+    props.solrHttpMode = 'secret';
+  }
+
   if (props.activemq && requiresActiveMqCredentials(props.acsVersion)) {
     props.activeMqCredentials = true;
   }
@@ -782,6 +840,10 @@ function getAvailableMemory(props) {
     ram -= 256;
   }
   if (props.ocr) {
+    ram -= 512;
+  }
+  // The Jeci fork adds a standalone trackers service (fixed 512m).
+  if (props.searchType === 'jeci') {
     ram -= 512;
   }
   return ram;

--- a/generators/app/templates/26.1/.env
+++ b/generators/app/templates/26.1/.env
@@ -8,6 +8,13 @@ MARIADB_TAG=11.3.2
 TRANSFORM_ENGINE_TAG=5.4.0
 ACTIVEMQ_TAG=6.2.1-jre17-rockylinux8
 
+# Jeci community fork (Solr 9 / Java 17, externalized trackers) — only used when --searchType=jeci.
+# The fork is compiled FROM SOURCE by the multi-stage ./search Dockerfile during
+# `docker compose build`, so no local JDK/Maven or manual clone is required.
+# Override these to build a different fork, branch, tag or commit.
+JECI_REPO=https://github.com/jecicorp/AlfrescoSearchServices.git
+JECI_REF=develop
+
 # Server properties
 SERVER_NAME=<%=serverName%>
 

--- a/generators/app/templates/26.1/docker-compose.yml
+++ b/generators/app/templates/26.1/docker-compose.yml
@@ -284,6 +284,7 @@ services:
             - mariadb-logs:/var/log/mysql <% } %>
     <% } %>
 
+    <% if (searchType == 'alfresco') { %>
     solr6:
         build:
           context: ./search
@@ -351,6 +352,86 @@ services:
             - ./data/solr-data:/opt/alfresco-search-services/data <% } %> <% if (windows == 'true') { %>
             - solr-data:/opt/alfresco-search-services/data <% } %> <% if (solrHttpMode == 'https') { %>
             - ./keystores/solr:/opt/alfresco-search-services/keystore <% } %>
+    <% } else { %>
+    # Jeci community fork of Alfresco Search Services: vanilla Apache Solr 9 / Java 17.
+    # Solr only serves queries and stores the index; the indexing trackers run as a
+    # separate service (see "trackers" below). Communication uses shared secret only.
+    # The image is COMPILED FROM SOURCE by the multi-stage ./search Dockerfile, so no
+    # local JDK/Maven or manual clone is needed — just `docker compose up`.
+    # Project: https://github.com/jecicorp/AlfrescoSearchServices
+    solr6:
+        build:
+          context: ./search
+          target: solr
+          args:
+            JECI_REPO: ${JECI_REPO}
+            JECI_REF: ${JECI_REF}
+        # solr-init-core.sh creates the alfresco + archive cores from the rerank
+        # template on first boot, then starts Solr.
+        entrypoint: ["/opt/alfresco-search-services/solr-init-core.sh"]
+        deploy:
+            resources:
+                limits:
+                    memory: <%=ram/4%>m
+        environment:
+            SOLR_JAVA_MEM: "-XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"
+            #Solr needs to know how to register itself with Alfresco
+            SOLR_ALFRESCO_HOST: "alfresco"
+            SOLR_ALFRESCO_PORT: "8080"
+            #Alfresco needs to know how to call solr
+            SOLR_SOLR_HOST: "solr6"
+            SOLR_SOLR_PORT: "8983"
+            #Create the default alfresco and archive cores
+            SOLR_CREATE_ALFRESCO_DEFAULTS: "alfresco,archive"
+            ALFRESCO_SECURE_COMMS: "secret"
+            JAVA_TOOL_OPTIONS: "-Dalfresco.secureComms.secret=<%=secretPassword%>"
+        depends_on:
+          alfresco:
+            condition: service_healthy<% if (proxyType == 'traefik') { %>
+        labels:
+            - "traefik.enable=true"<% if (https == 'true') { %>
+            - "traefik.http.routers.solr.entrypoints=websecure"<% } else { %>
+            - "traefik.http.routers.solr.entrypoints=web"<% } %>
+            - "traefik.http.routers.solr.rule=PathPrefix(`/solr`)"
+            - "traefik.http.services.solr.loadbalancer.server.port=8983"
+            - "traefik.http.middlewares.solrauth.basicauth.usersfile=/etc/nginx/conf.d/nginx.htpasswd"
+            - "traefik.http.routers.solr.middlewares=solrauth@docker"<% } %>
+        # Persist only the index (data/). solrhome holds the core config and the
+        # baked-in rerank/noRerank templates that solr-init-core.sh copies from;
+        # mounting an empty volume over it would mask the templates and the core
+        # would fail to load. Cores are recreated from templates on each boot.
+        volumes: <% if (windows == 'false') { %>
+            - ./data/solr-data:/opt/alfresco-search-services/data <% } %> <% if (windows == 'true') { %>
+            - solr-data:/opt/alfresco-search-services/data <% } %>
+
+    # Standalone indexing trackers (Spring Boot). Polls the Repository and indexes
+    # into Solr via SolrJ. Tunable live via ALFRESCO_TRACKER_* env vars (no rebuild).
+    # Built from the same multi-stage ./search Dockerfile (trackers target); the
+    # shared builder stage is cached, so the source is compiled only once.
+    trackers:
+        build:
+          context: ./search
+          target: trackers
+          args:
+            JECI_REPO: ${JECI_REPO}
+            JECI_REF: ${JECI_REF}
+        deploy:
+            resources:
+                limits:
+                    memory: 512m
+        environment:
+            ALFRESCO_TRACKER_SOLR_URL: "http://solr6:8983/solr"
+            ALFRESCO_TRACKER_SOLR_COLLECTIONS: "alfresco,archive"
+            ALFRESCO_TRACKER_REPOSITORY_URL: "http://alfresco:8080/alfresco"
+            ALFRESCO_TRACKER_REPOSITORY_SECURECOMMS: "secret"
+            ALFRESCO_TRACKER_REPOSITORY_SHAREDSECRET: "<%=secretPassword%>"
+        depends_on:
+          alfresco:
+            condition: service_healthy
+        volumes: <% if (windows == 'false') { %>
+            - ./data/trackers-data:/opt/solr/data <% } %> <% if (windows == 'true') { %>
+            - trackers-data:/opt/solr/data <% } %>
+    <% } %>
 
     <% if (activemq == 'true') { %>
     activemq:
@@ -541,7 +622,8 @@ volumes:
     postgres-logs: <% } %> <% if (db == 'mariadb') { %>
     mariadb-data:
     mariadb-logs: <% } %>
-    solr-data: <% if (ocr == 'true') { %>
+    solr-data: <% if (searchType == 'jeci') { %>
+    trackers-data: <% } %> <% if (ocr == 'true') { %>
     ocr-input:
     ocr-output: <% } %>
 <% } %>

--- a/generators/app/templates/images/search-jeci/Dockerfile
+++ b/generators/app/templates/images/search-jeci/Dockerfile
@@ -1,0 +1,128 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for the Jeci community fork of Alfresco Search Services
+# (vanilla Apache Solr 9 / Java 17, with the indexing trackers externalized).
+#
+# This image compiles the fork FROM SOURCE inside the builder stage, so users of
+# alfresco-docker-installer need only Docker — no local JDK, Maven, or manual clone.
+# `docker compose up` clones + builds + runs everything.
+#
+# Two runtime images are produced from one shared builder, selected with --target:
+#   * solr     -> Solr 9 query + index-storage node
+#   * trackers -> standalone Spring Boot indexing trackers
+#
+# NOTE: This Dockerfile is intended to be contributed back to the Jeci project
+# (https://github.com/jecicorp/AlfrescoSearchServices). Once it lives in that repo,
+# the builder stage can drop the `git clone` and use `COPY . .` against the repo
+# as build context instead.
+
+# ---------------------------------------------------------------------------
+# Builder: clone the fork and compile with Java 17 (Temurin)
+# ---------------------------------------------------------------------------
+FROM maven:3.9-eclipse-temurin-17 AS builder
+
+# Override to build a different fork/branch/commit without editing this file.
+ARG JECI_REPO=https://github.com/jecicorp/AlfrescoSearchServices.git
+ARG JECI_REF=develop
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch "${JECI_REF}" "${JECI_REPO}" /src
+WORKDIR /src
+
+# Build the Solr distribution ZIP and the trackers Spring Boot JAR in one pass.
+# The BuildKit cache mount keeps the Maven repo warm across rebuilds.
+#
+# The build references an internal artifact (org.alfresco:alfresco-license-headers)
+# that normally comes from Jeci's private Nexus. Reconstruct it from the in-repo
+# license-headers/ content and install it into the SAME cached .m2 the build uses
+# (a separate RUN would write under the cache mount and be shadowed). The license
+# goals themselves are skipped (they only stamp/check headers, not the binaries).
+RUN --mount=type=cache,target=/root/.m2 \
+    (cd license-headers && jar cf /tmp/alfresco-license-headers-1.0.jar .) \
+    && mvn -B -q org.apache.maven.plugins:maven-install-plugin:3.1.1:install-file \
+         -Dfile=/tmp/alfresco-license-headers-1.0.jar \
+         -DgroupId=org.alfresco -DartifactId=alfresco-license-headers \
+         -Dversion=1.0 -Dpackaging=jar \
+    && mvn -B -DskipTests \
+        -Dlicense.skipUpdateLicense=true -Dlicense.skipAddThirdParty=true \
+        clean install \
+        -pl search-services/alfresco-solrclient-lib,search-services/alfresco-search,search-services/packaging,search-services/alfresco-indexing-trackers -am
+
+# Collect the distribution ZIP at a stable path for the runtime stage.
+RUN mkdir -p /dist && cp search-services/packaging/target/alfresco-search-services-*.zip /dist/
+
+# ---------------------------------------------------------------------------
+# Runtime: Solr 9 (query serving + index storage)
+# ---------------------------------------------------------------------------
+FROM alfresco/alfresco-base-java:jre17-rockylinux9 AS solr
+
+ENV DIST_DIR=/opt/alfresco-search-services
+ENV SOLR_DATA_DIR_ROOT=$DIST_DIR/data
+ENV SOLR_SOLR_MODEL_DIR=$DIST_DIR/data/alfrescoModels
+ENV LANG=C.UTF-8
+
+ARG USERNAME=solr
+ARG USERID=33007
+
+COPY --from=builder /dist/ /tmp/dist/
+
+RUN set -x \
+    && useradd -c "Alfresco ${USERNAME}" -M -s /bin/bash -u ${USERID} -o ${USERNAME} \
+    && yum install -y unzip lsof ca-certificates procps-ng wget \
+    && yum clean all \
+    && unzip /tmp/dist/*.zip -d /opt/ \
+    && rm -rf /tmp/dist \
+    && mkdir -p $DIST_DIR/data \
+    && mv $DIST_DIR/solrhome/alfrescoModels $DIST_DIR/data/ \
+    && chown -R ${USERNAME}:${USERNAME} $DIST_DIR \
+    && echo '#Docker Setup' >> $DIST_DIR/solr.in.sh \
+    && echo 'SOLR_OPTS="$SOLR_OPTS -Dsolr.data.dir.root=$SOLR_DATA_DIR_ROOT -Dsolr.solr.model.dir=$SOLR_SOLR_MODEL_DIR -Dsolr.allowPaths=$DIST_DIR/solrhome"' >> $DIST_DIR/solr.in.sh \
+    && echo '# Solr 9 ships ICU analysis (used by the Alfresco schema) in the analysis-extras module' >> $DIST_DIR/solr.in.sh \
+    && echo 'SOLR_MODULES=analysis-extras' >> $DIST_DIR/solr.in.sh \
+    && echo '# Solr 9 binds to 127.0.0.1 by default; bind to all interfaces so the container is reachable' >> $DIST_DIR/solr.in.sh \
+    && echo 'SOLR_JETTY_HOST=0.0.0.0' >> $DIST_DIR/solr.in.sh \
+    && echo '# Solr 9 enables the Java SecurityManager by default; the Alfresco plugins need unrestricted access' >> $DIST_DIR/solr.in.sh \
+    && echo 'SOLR_SECURITY_MANAGER_ENABLED=false' >> $DIST_DIR/solr.in.sh
+
+# Startup helpers (not part of the distribution ZIP; taken from the source tree).
+COPY --from=builder /src/search-services/packaging/src/docker/search_config_setup.sh $DIST_DIR/solr/bin/
+COPY --from=builder /src/search-services/packaging/src/docker/solr-init-core.sh $DIST_DIR/
+RUN chmod +x $DIST_DIR/solr/bin/search_config_setup.sh $DIST_DIR/solr-init-core.sh \
+    && (mv $DIST_DIR/licenses /licenses || true)
+
+WORKDIR $DIST_DIR
+
+VOLUME $DIST_DIR/data
+VOLUME $DIST_DIR/solrhome
+VOLUME $DIST_DIR/keystores
+
+EXPOSE 8983
+USER ${USERNAME}
+CMD $DIST_DIR/solr/bin/search_config_setup.sh "$DIST_DIR/solr/bin/solr start -f"
+
+# ---------------------------------------------------------------------------
+# Runtime: standalone indexing trackers (Spring Boot)
+# ---------------------------------------------------------------------------
+# Use the multi-arch Ubuntu-based JRE (the -alpine tag has no arm64 manifest,
+# which breaks the build on Apple Silicon / arm64 hosts).
+FROM eclipse-temurin:17-jre AS trackers
+
+LABEL org.opencontainers.image.title="Alfresco Indexing Trackers (Jeci fork)"
+LABEL org.opencontainers.image.description="Polls the Alfresco Repository and indexes into Solr 9 via SolrJ"
+
+RUN groupadd -g 33007 trackers && useradd -u 33007 -g trackers -M -s /usr/sbin/nologin trackers
+
+WORKDIR /app
+COPY --from=builder /src/search-services/alfresco-indexing-trackers/target/alfresco-indexing-trackers-*.jar /app/alfresco-indexing-trackers.jar
+RUN mkdir -p /opt/solr/data/alfrescoModels && chown -R trackers:trackers /app /opt/solr/data
+
+USER trackers
+EXPOSE 8085
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD wget -q --spider http://localhost:8085/actuator/health || exit 1
+
+ENTRYPOINT ["java", "-jar", "/app/alfresco-indexing-trackers.jar"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-alfresco-docker-installer",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Yeoman generator for Alfresco Docker installer (ESM-ready)",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## What

Adds a new **search engine option** for **ACS 26.1**: `--searchType=jeci` (prompt: *"Which search engine would you like to use?"*). It generates a search tier based on the [Jeci community fork of Alfresco Search Services](https://github.com/jecicorp/AlfrescoSearchServices) — **vanilla Apache Solr 9.10.1 / Java 17**, with the indexing trackers running as a **standalone Spring Boot service** instead of inside the Solr webapp.

The default (`alfresco`) is unchanged: existing invocations keep producing the stock Solr 6 stack.

## Why

Alfresco Community's search still ships on an Alfresco-patched Solr 6 (Lucene 6, Java 11). This option lets users try a modern, vanilla-Solr-9 search tier through the same installer they already use — with no change to AFTS, the Search API, or ACL filtering.

## How it works

- **New multi-stage `images/search-jeci/Dockerfile`** compiles the fork **from source** inside Docker, so users need only Docker — no local JDK, Maven, or manual clone. `docker compose up --build` does everything; the build is cached afterwards.
- **26.1 `docker-compose.yml`** branches on `searchType`:
  - `alfresco` → the existing stock `solr6` service (unchanged).
  - `jeci` → a `solr6` (query + index storage) **plus** a `trackers` (standalone indexing) service, pre-wired with a shared secret.
- **`.env`** gains `JECI_REPO` / `JECI_REF` to pick the fork's branch/tag/commit.
- `jeci` **forces shared-secret** comms (the mode the fork supports end to end; mTLS on the tracker→Solr leg isn't there yet).
- Migrates the deprecated Inquirer `list` prompts to `select` (removes the `\`list\` prompt is deprecated` warning under yeoman-generator 7.5.1 / Inquirer 13).
- Bumps version **1.3.0 → 1.4.0**.

## Scope

Targets **ACS 26.1** only for now. Extending to 23.x / 25.x is straightforward follow-up (the `solr6` block is the same shape across those templates).

## Testing

Generated a 26.1 + `jeci` stack with `yo alfresco-docker-installer --searchType=jeci` and brought it up. Verified end to end against the Alfresco Search API:

- the Solr 9 cores (`alfresco`, `archive`) load with the Alfresco plugins;
- trackers report healthy (repository + Solr UP) and index transactions;
- a freshly uploaded document is findable **by name** (metadata) within seconds and **by a word inside its content** (full-text) shortly after;
- a control query for a nonexistent token returns 0 results.

`docker compose config` validates for `jeci` × {nginx, traefik, windows} and the stock path is unaffected.